### PR TITLE
Fix sale date timezone and synchronization issues

### DIFF
--- a/src/components/Reusable/SaleDatePicker.jsx
+++ b/src/components/Reusable/SaleDatePicker.jsx
@@ -1,14 +1,27 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { TextField } from "@mui/material";
 
 const SaleDatePicker = ({ initialDate = new Date(), onDateChange }) => {
   // Format the initial date to YYYY-MM-DD format for the input
+  // Use local date methods to avoid timezone conversion issues
   const formatDate = (date) => {
-    return date.toISOString().split("T")[0];
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
   };
 
   // Initialize state with today's date or provided initialDate
   const [saleDate, setSaleDate] = useState(formatDate(initialDate));
+
+  // Sync internal state when initialDate prop changes
+  // Only update if the formatted dates are actually different to avoid unnecessary re-renders
+  useEffect(() => {
+    const formattedInitialDate = formatDate(initialDate);
+    if (formattedInitialDate !== saleDate) {
+      setSaleDate(formattedInitialDate);
+    }
+  }, [initialDate]);
 
   const handleDateChange = (e) => {
     const newDate = e.target.value;


### PR DESCRIPTION
- Fixed date showing tomorrow's date due to timezone conversion
  - Changed formatDate to use local date methods instead of toISOString()
  - Prevents UTC conversion that was shifting dates forward in US timezones

- Fixed date resetting to wrong date after user selection
  - Added useEffect to sync internal state with initialDate prop changes
  - Only updates when dates actually differ to avoid unnecessary re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)