### PR TITLE
Fix: Ensure tips always go to actual stylist, never house sales

### DIFF
--- a/src/components/sales/SalesForm.jsx
+++ b/src/components/sales/SalesForm.jsx
@@ -343,14 +343,21 @@ function SalesForm() {
       const hasProducts = productItems.some((item) => !item.isBackBar);
       const hasServices = serviceItems.length > 0;
 
+      // Validate: Tips must always go to an actual stylist, never to house sales
+      if (tipAmount > 0 && !selectedStylist) {
+        alert("You must select a stylist when adding a tip.");
+        window.saleInProgress = false;
+        return;
+      }
+
       const shouldUseProductStylist = productStylistId && hasProducts;
       const clientId = selectedCustomer ? selectedCustomer.id : null;
       const stylistId = selectedStylist ? selectedStylist.id : null;
 
       let saleResults;
 
-      // 1. PRODUCT-ONLY SALE
-      if (shouldUseProductStylist && !hasServices) {
+      // 1. PRODUCT-ONLY SALE (without tip - goes to house sales)
+      if (shouldUseProductStylist && !hasServices && tipAmount === 0) {
         saleResults = await handleProductOnlySale(
           productItems,
           clientId,
@@ -360,6 +367,32 @@ function SalesForm() {
           taxRate,
           tipAmount,
         );
+      }
+      // 1B. PRODUCT-ONLY SALE WITH TIP (use actual stylist, not product stylist)
+      else if (shouldUseProductStylist && !hasServices && tipAmount > 0) {
+        // Treat as product-only sale but assign to actual stylist
+        const productsData = productItems.map((item) => ({
+          inventoryId: item.product.id,
+          price: item.price,
+          quantity: item.quantity,
+          isBackBar: !!item.isBackBar,
+        }));
+
+        const saleData = {
+          ClientId: clientId,
+          StylistId: stylistId,
+          services: [],
+          products: productsData,
+          subtotal,
+          tax: productTax,
+          tip: tipAmount,
+          total: subtotal + productTax + tipAmount,
+          paymentMethod: paymentMethod || "back-bar",
+          saleDate: saleDate,
+        };
+
+        await ipc.invoke("create-sale", saleData);
+        saleResults = saleData;
       }
       // 2. MIXED SALE WITHOUT SPLIT PAYMENT
       else if (shouldUseProductStylist && hasServices && !splitPayment) {

--- a/src/components/sales/SalesFormRefactored.jsx
+++ b/src/components/sales/SalesFormRefactored.jsx
@@ -323,14 +323,21 @@ function SalesForm() {
       const hasProducts = productItems.some((item) => !item.isBackBar);
       const hasServices = serviceItems.length > 0;
 
+      // Validate: Tips must always go to an actual stylist, never to house sales
+      if (tipAmount > 0 && !selectedStylist) {
+        alert("You must select a stylist when adding a tip.");
+        window.saleInProgress = false;
+        return;
+      }
+
       const shouldUseProductStylist = productStylistId && hasProducts;
       const clientId = selectedCustomer ? selectedCustomer.id : null;
       const stylistId = selectedStylist ? selectedStylist.id : null;
 
       let saleResults;
 
-      // 1. PRODUCT-ONLY SALE
-      if (shouldUseProductStylist && !hasServices) {
+      // 1. PRODUCT-ONLY SALE (without tip - goes to house sales)
+      if (shouldUseProductStylist && !hasServices && tipAmount === 0) {
         saleResults = await handleProductOnlySale(
           productItems,
           clientId,
@@ -340,6 +347,32 @@ function SalesForm() {
           taxRate,
           tipAmount,
         );
+      }
+      // 1B. PRODUCT-ONLY SALE WITH TIP (use actual stylist, not product stylist)
+      else if (shouldUseProductStylist && !hasServices && tipAmount > 0) {
+        // Treat as product-only sale but assign to actual stylist
+        const productsData = productItems.map((item) => ({
+          inventoryId: item.product.id,
+          price: item.price,
+          quantity: item.quantity,
+          isBackBar: !!item.isBackBar,
+        }));
+
+        const saleData = {
+          ClientId: clientId,
+          StylistId: stylistId,
+          services: [],
+          products: productsData,
+          subtotal,
+          tax: productTax,
+          tip: tipAmount,
+          total: subtotal + productTax + tipAmount,
+          paymentMethod: paymentMethod || "back-bar",
+          saleDate: saleDate,
+        };
+
+        await ipc.invoke("create-sale", saleData);
+        saleResults = saleData;
       }
       // 2. MIXED SALE WITHOUT SPLIT PAYMENT
       else if (shouldUseProductStylist && hasServices && !splitPayment) {
@@ -354,6 +387,7 @@ function SalesForm() {
           taxRate,
           serviceTax,
           findStylistById,
+          tipAmount,
         );
       }
       // 3. SERVICE-ONLY SALE or NO PRODUCT STYLIST


### PR DESCRIPTION
Changes:
- Add validation to require stylist selection when a tip is added
- When creating product-only sales with tips, assign to selected stylist instead of product sales stylist (which could be "house")
- Separate logic for product-only sales with/without tips:
  - Without tip: Use product stylist (can be house sales)
  - With tip: Use actual selected stylist
- Update SalesForm.jsx and SalesFormRefactored.jsx with same logic

This ensures tips are always credited to the stylist who provided the service, never assigned to "house" sales accounts.